### PR TITLE
ci: switch to cachix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,10 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@v16
 
       - name: Set up Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v9
+        uses: cachix/cachix-action@v15
+        with:
+          name: sgt0
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Check evaluation
         run: |


### PR DESCRIPTION
magic-nix-cache-action is now deprecated due to changes in GitHub's API.