### PR TITLE
fpng: disable LTO

### DIFF
--- a/pkgs/vapoursynth-plugins/fpng/default.nix
+++ b/pkgs/vapoursynth-plugins/fpng/default.nix
@@ -35,6 +35,9 @@ stdenv.mkDerivation rec {
   '';
 
   mesonBuildType = "release";
+  mesonFlags = [
+    "-Db_lto=false"
+  ];
 
   meta = with lib; {
     description = "fpng for VapourSynth";


### PR DESCRIPTION
Fixes an "undefined symbol" error on plugin init.