### PR TITLE
treewide: remove useFetchCargoVendor

### DIFF
--- a/everything-shell.nix
+++ b/everything-shell.nix
@@ -15,6 +15,7 @@ with pkgs; let
     vapoursynthPlugins.ares
     vapoursynthPlugins.bilateral
     vapoursynthPlugins.bs
+    vapoursynthPlugins.cambi
     vapoursynthPlugins.colorbars
     vapoursynthPlugins.depan
     vapoursynthPlugins.descale

--- a/pkgs/vapoursynth-plugins/cambi/default.nix
+++ b/pkgs/vapoursynth-plugins/cambi/default.nix
@@ -16,7 +16,6 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-n6RE1Kz/4P+vu6xRhUYtHS+n0C1H9saguNkeMUa1WhI=";
   };
 
-  useFetchCargoVendor = true;
   cargoHash = "sha256-XWXeNVFr3JDHiETnR7jP/S8bYNUPEAqTOOwPxC2EWOs=";
 
   postInstall = ''

--- a/pkgs/vapoursynth-plugins/fftspectrum_rs/default.nix
+++ b/pkgs/vapoursynth-plugins/fftspectrum_rs/default.nix
@@ -16,7 +16,6 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-I4F5CzHYnsqxtQzWtY4meBArmevpFFVUNiSOUWBazhM=";
   };
 
-  useFetchCargoVendor = true;
   cargoHash = "sha256-DXalTud/+7sQ8iQ9F6jaccN+Qse5cSxOkGaUxr+uzYE=";
 
   postInstall = ''

--- a/pkgs/vapoursynth-plugins/webp/default.nix
+++ b/pkgs/vapoursynth-plugins/webp/default.nix
@@ -16,7 +16,6 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-zA2m6iRQN4Q0loCY3v5weQfFL8oB8DUtdxNdEZ64Vz8=";
   };
 
-  useFetchCargoVendor = true;
   cargoHash = "sha256-KpH1lWEUFP3c7JUuTqUT7yzTfZ6Iej56vhSBCCc/fB0=";
 
   postInstall = ''


### PR DESCRIPTION
useFetchCargoVendor is non-optional and enabled by default as of 25.05.